### PR TITLE
Trigger Firing for Unused Ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Versões antigas disponíveis no diretório [Template](./Template). \
 
 ### TESTED VERSION
 
-Esta template foi testada somente com os NVRs Intelbras "NVD 3116 P" e "NVD 3316 P". Também deve funcionar em outros NVRs Intelbras ou Dahua. \
-_This template was tested on Intelbras NVR "NVD 3116 P" and "NVD 3316 P". It should also work with other Intelbras or Dahua NVRs as well._
+Esta template foi testada somente com os NVRs Intelbras "NVD 3116 P", "NVD 3316 P" e "NVD 1408" . Também deve funcionar em outros NVRs Intelbras ou Dahua. \
+_This template was tested on Intelbras NVR "NVD 3116 P", "NVD 3316 P" and "NVD 1408". It should also work with other Intelbras or Dahua NVRs as well._
 
 <BR>
 

--- a/Template/Intelbras_NVR_template_v745.yaml
+++ b/Template/Intelbras_NVR_template_v745.yaml
@@ -1257,7 +1257,9 @@ zabbix_export:
                     - tag: Status
                       value: absent
                 - uuid: 751f317495fb42e1927b45d10327385d
-                  expression: 'last(/Intelbras Dahua NVR by SNMP/remoteDevice.Status[{#SNMPINDEX}],#1)=2'
+                  expression: 'last(/Intelbras Dahua NVR by SNMP/remoteDevice.Status[{#SNMPINDEX}],#1)=2 and last(/Intelbras Dahua NVR by SNMP/remoteDevice.Status[{#SNMPINDEX}],#2)=1'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Intelbras Dahua NVR by SNMP/remoteDevice.Status[{#SNMPINDEX}])=1'
                   name: 'Camera {#SNMPINDEX} disconnected - {#CAM_NAME}'
                   opdata: '{#CAM_NAME} - {#CAM_STATUS}'
                   priority: WARNING


### PR DESCRIPTION
Previously, Zabbix trigger alerts even when no cameras were connected to a port. With this update, the trigger now activates only when a connected device becomes disconnected. Once the device reconnects, the problem is automatically cleared, reducing false alerts.

Template tested with NVD 1408 as well; it works flawlessly. Great job!